### PR TITLE
Update piston dependencies to current version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,17 +545,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "piston"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "pistoncore-event_loop 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pistoncore-input 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pistoncore-window 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-event_loop 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-input 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-window 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piston-float"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -570,29 +570,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "piston-viewport"
-version = "0.5.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "piston-float 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston-float 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piston2d-graphics"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "interpolation 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-texture 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston-viewport 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston-viewport 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "read_color 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusttype 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "vecmath 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vecmath 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piston2d-opengl_graphics"
-version = "0.59.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -601,48 +601,49 @@ dependencies = [
  "khronos_api 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-shaders_graphics2d 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-texture 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston2d-graphics 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston-viewport 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston2d-graphics 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "shader_version 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pistoncore-event_loop"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "pistoncore-input 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pistoncore-window 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-input 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-window 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pistoncore-glutin_window"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gl 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pistoncore-input 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pistoncore-window 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-input 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-window 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "shader_version 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pistoncore-input"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston-viewport 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston-viewport 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pistoncore-window"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "pistoncore-input 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-input 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "shader_version 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -812,10 +813,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rust_game"
 version = "0.1.0"
 dependencies = [
- "piston 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston2d-graphics 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston2d-opengl_graphics 0.59.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pistoncore-glutin_window 0.54.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston2d-graphics 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston2d-opengl_graphics 0.62.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-glutin_window 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -967,10 +968,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vecmath"
-version = "0.3.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "piston-float 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston-float 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1180,17 +1181,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum piston 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cce7b1869f6388131f793fc55ebb05b8ec4c7203faffaecf0844a25b98ee3167"
-"checksum piston-float 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b058c3a640efd4bcf63266512e4bb03187192c1b29edd38b16d5a014613e3199"
+"checksum piston 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90af400cac8659b96a81908c178773fa26e2f1805155b0972d7450146e96ea96"
+"checksum piston-float 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f900be47e312e126cc71d35548e8e31edd3901b92ab82d1c4c4757e6b5526564"
 "checksum piston-shaders_graphics2d 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "97bc17dac1dfff3e5cb84116062c7b46ff9d3dc0d88696a46d2f054cf64a10b6"
 "checksum piston-texture 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3649b5f9d1ba48d95207976118e9e2ed473c1de36f6f79cc1b7ed5b75b655b61"
-"checksum piston-viewport 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d96dd995f7dabe6d57cda668ec0fda39d6fe6e1e0b23f772582f383f2013611"
-"checksum piston2d-graphics 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3403f3d6416d7d5563912f03528909e83efc061d0944fb56ac3ce37745f8bfee"
-"checksum piston2d-opengl_graphics 0.59.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c1bd3137391e9803acf12c8364aa75cc641ee6964d8c3b445a7f6e636e376bb1"
-"checksum pistoncore-event_loop 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efb4398cd25ae032e7caddfdc9a3d1ebfdc16ab668cf8d79fe8044b9ed3841a"
-"checksum pistoncore-glutin_window 0.54.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6c000159cf92287a7da23b30dab5307094ac00787f56bf0693ad46fdfd765173"
-"checksum pistoncore-input 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c612ce242c7bac8e96426a0ca34275fd980af440f0cca7c6c0e840ef8a4052f"
-"checksum pistoncore-window 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)" = "863934d0663db43e6737ac8bf947e09fc2d4d06ab95b46a75b999e8bc34b1ddd"
+"checksum piston-viewport 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01abb19b781051290d0837b9294c26d419cc4156907c21ffe86705e219446798"
+"checksum piston2d-graphics 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8076479779b8191e87331df71426ebcdf7c21b3017cb6d8cb5dd49f0231c0114"
+"checksum piston2d-opengl_graphics 0.62.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8887bef344b9c5b0648badcc6a2856ea3105313d69bcc8ec671fbadc282e1501"
+"checksum pistoncore-event_loop 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4a75d7716ffe4c3c30cb4de05124b7006982eed0764bffb770e0261b429a5dea"
+"checksum pistoncore-glutin_window 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cec807f19ac69df226ee7ce15b3b7e589b1af859388f489cb86d126eea3c67b0"
+"checksum pistoncore-input 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92bcba2699bc8083d4d448c328e419377f7de43a6125591598ad984497d45bb1"
+"checksum pistoncore-window 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a07f8c43f7725b301fdb0ae9ab57fac3174498c524379bcce6757db1515da422"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum png 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "63daf481fdd0defa2d1d2be15c674fbfa1b0fd71882c303a91f9a79b3252c359"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
@@ -1228,7 +1229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum tiff 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1e4834f28a0330cb9f3f2c87d2649dca723cb33802e2bdcf18da32759fbec7ce"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum vecmath 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1bdd6034ee9c1e5e12485f3e4120e12777f6c81cf43bf9a73bff98ed2b479afe"
+"checksum vecmath 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "956ae1e0d85bca567dee1dcf87fb1ca2e792792f66f87dced8381f99cd91156a"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum wayland-client 0.21.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e77d1e6887f07ea2e5d79a3d7d03a875e62d3746334a909b5035d779d849a523"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 rand_chacha = "0.1.1"
 rand_core = "0.4.0"
 rand = "0.6.5"
-piston = "0.42.0"
-pistoncore-glutin_window = "0.54.0"
-piston2d-graphics = "0.30.0"
-piston2d-opengl_graphics = "0.59.0"
+piston = "0.43.0"
+pistoncore-glutin_window = "0.55.0"
+piston2d-graphics = "0.32.0"
+piston2d-opengl_graphics = "0.62.0"
 
 

--- a/src/entity/player.rs
+++ b/src/entity/player.rs
@@ -60,7 +60,7 @@ impl Player {
     fn convert_to_unit_vector(&self, vector: [f64; 2]) -> [f64;2] {
         let ax = vector[0].abs();
         let ay = vector[1].abs();
-        let mut ratio = 1.0;
+        let mut ratio;
         match ax > ay {
             true => {
                 ratio = 1.0 / ax;

--- a/src/game/game_model.rs
+++ b/src/game/game_model.rs
@@ -12,21 +12,19 @@ pub struct GameModel {
     pub level: Level,
     pub player: Player,
     pub beacon: Beacon,
-    rng: RNG,
 }
 
 impl GameModel {
     pub fn new(seed: Seed) -> Self {
-        let mut level = Level::new(seed);
+        let level = Level::new(seed);
         let mut rng = from_seed(seed);
         let beacon_spawn = GameModel::find_beacon_spawn(&level, &mut rng);
-        let mut beacon = Beacon::new(beacon_spawn);
+        let beacon = Beacon::new(beacon_spawn);
         let player_spawn = GameModel::find_player_spawn(&level, &beacon, &mut rng);
-        let mut player = Player::new([player_spawn.0 as f64 * 20.0, player_spawn.1 as f64 * 20.0]);
+        let player = Player::new([player_spawn.0 as f64 * 20.0, player_spawn.1 as f64 * 20.0]);
         
         Self {
             level: level,
-            rng: rng,
             player: player,
             beacon: beacon,
         }

--- a/src/game/game_view.rs
+++ b/src/game/game_view.rs
@@ -2,7 +2,7 @@ use crate::game::GameModel;
 use crate::traits::shape::Shape;
 use crate::traits::state::State;
 use crate::entity::{tile, attack};
-use graphics::{Context, Graphics,Transformed};
+use graphics::{Context, Graphics};
 use graphics::types::Color;
 use std::f64;
 


### PR DESCRIPTION
This closes #53 and fixes all compiler warnings regarding unused fields or variables that don't need to be mutable.