### PR TITLE
fix: remove unneeded mutable

### DIFF
--- a/src/game/game_struct.rs
+++ b/src/game/game_struct.rs
@@ -32,7 +32,7 @@ impl Game {
         let config = input::handle_init_input();
         // Create the seed used for the run
         let mut seed = random::create_seed(config.debug);
-        let mut controller: GameController;
+        let controller: GameController;
         loop {
 
             if let Some(c) = GameController::new(seed) {


### PR DESCRIPTION
- Removed unneeded mutex that showed in warning when running `cargo build`